### PR TITLE
(ref): avoid tons of clarifying questions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ var/
 wheels/
 pip-wheel-metadata/
 share/python-wheels/
-*.egg-info/
+*egg-info/
 .installed.cfg
 *.egg
 MANIFEST
@@ -44,3 +44,4 @@ logs/
 Thumbs.db
 
 problem_statement.pdf
+mail_index.sqlite

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -77,3 +77,21 @@ Requirements:
 Reply:"""
 
 
+def build_clarification_prompt(current_context: str, missing_slots: list[str]) -> str:
+    missing = ", ".join(missing_slots) if missing_slots else "the missing information"
+    return f"""
+You must ask a SINGLE concise clarification message that covers all missing blocking details at once.
+
+EVIDENCE — CURRENT EMAIL
+{current_context}
+
+Missing blocking slots: {missing}
+
+Rules:
+- Ask ONE message, bullet or short list is fine.
+- Be specific and actionable. Offer 2-3 options where possible.
+- Be polite and brief. Do not include any other content.
+
+Clarification message:
+"""
+


### PR DESCRIPTION
Implemented clarification control:

- Per-thread state clarify_state keyed by conversationId with a max of 1 clarification.
  Slot detection for blocking info (time/date, document) and low-confidence gating.
  One aggregated clarification message via a new clarifying prompt; else best-effort draft.

How this solves it:
- Resolves from history first; only if blocking slots are missing and confidence is low, asks once with all questions together.
- Caps the loop (stateful) and falls back to a best-effort draft on subsequent turns.